### PR TITLE
[imp.3] enable interpolateParams

### DIFF
--- a/go/main.go
+++ b/go/main.go
@@ -189,7 +189,7 @@ func NewMySQLConnectionEnv() *MySQLConnectionEnv {
 }
 
 func (mc *MySQLConnectionEnv) ConnectDB() (*sqlx.DB, error) {
-	dsn := fmt.Sprintf("%v:%v@tcp(%v:%v)/%v?parseTime=true&loc=Asia%%2FTokyo", mc.User, mc.Password, mc.Host, mc.Port, mc.DBName)
+	dsn := fmt.Sprintf("%v:%v@tcp(%v:%v)/%v?parseTime=true&loc=Asia%%2FTokyo&interpolateParams=true", mc.User, mc.Password, mc.Host, mc.Port, mc.DBName)
 	return sqlx.Open("mysql", dsn)
 }
 


### PR DESCRIPTION
before
```
14:45:34.101704 score: 16466(16468 - 2) : pass
14:45:34.101746 deduction: 0 / timeout: 22

+-------+--------+--------------------+-------+-------+-------+----------+
| COUNT | METHOD |        URI         |  MIN  |  AVG  |  MAX  |   SUM    |
+-------+--------+--------------------+-------+-------+-------+----------+
| 74175 | POST   | /api/condition/\w+ | 0.024 | 0.015 | 0.172 | 1127.228 |
+-------+--------+--------------------+-------+-------+-------+----------+

# Profile
# Rank Query ID                      Response time Calls R/Call V/M   Item
# ==== ============================= ============= ===== ====== ===== ====
#    1 0xFFFCA4D67EA0A788813031B8... 37.8133 37.3%  8770 0.0043  0.00 COMMIT
#    2 0x931A992E852C61FC6D46141A... 33.1311 32.6%  9940 0.0033  0.01 SELECT isu_condition
#    3 0x9C6C682008AE0D08F3E2A004... 13.3727 13.2%  2622 0.0051  0.01 SELECT isu_condition
#    4 0xDA556F9115773A1A99AA0165...  5.6958  5.6% 55039 0.0001  0.00 ADMIN PREPARE
#    5 0xB8B32624C3268C0925657C30...  4.0463  4.0%  7384 0.0005  0.00 INSERT isu_condition
#    6 0x5F580A12ADA1633C9634298B...  3.3390  3.3%   724 0.0046  0.01 SELECT isu_condition
# MISC 0xMISC                         4.1065  4.0% 98929 0.0000   0.0 <90 ITEMS>
```

after
```
15:00:49.164469 score: 17228(17230 - 2) : pass
15:00:49.164500 deduction: 0 / timeout: 22

+-------+--------+--------------------+-------+-------+-------+----------+
| COUNT | METHOD |        URI         |  MIN  |  AVG  |  MAX  |   SUM    |
+-------+--------+--------------------+-------+-------+-------+----------+
| 73029 | POST   | /api/condition/\w+ | 0.001 | 0.022 | 0.128 | 1612.865 |
+-------+--------+--------------------+-------+-------+-------+----------+

# Profile
# Rank Query ID                      Response time Calls R/Call V/M   Item
# ==== ============================= ============= ===== ====== ===== ====
#    1 0xFFFCA4D67EA0A788813031B8... 37.2486 38.2%  8773 0.0042  0.00 COMMIT
#    2 0x931A992E852C61FC6D46141A... 34.5521 35.4% 11794 0.0029  0.01 SELECT isu_condition
#    3 0x9C6C682008AE0D08F3E2A004... 13.8273 14.2%  2710 0.0051  0.01 SELECT isu_condition
#    4 0xB8B32624C3268C0925657C30...  4.0401  4.1%  7276 0.0006  0.01 INSERT isu_condition
#    5 0x5F580A12ADA1633C9634298B...  3.9418  4.0%   772 0.0051  0.01 SELECT isu_condition
# MISC 0xMISC                         3.8727  4.0% 46764 0.0001   0.0 <89 ITEMS>
```